### PR TITLE
fix: add .nojekyll file generation for GitHub Pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,3 +66,7 @@ jinja_env = Environment(
 jinja_template = jinja_env.get_template('index.html')
 index = open('feeds/index.html', 'w')
 index.write(jinja_template.render(feeds=rendered_feeds))
+
+# Create .nojekyll file for GitHub Pages
+with open('feeds/.nojekyll', 'w') as f:
+    pass


### PR DESCRIPTION
## Summary

This PR fixes the failing publish action by ensuring a `.nojekyll` file is generated in the `feeds/` directory.

## Changes

- Modified `main.py` to create a `.nojekyll` file in the `feeds/` directory
- This prevents GitHub Pages from processing the content with Jekyll

## Additional Notes

If the action still fails, please verify that GitHub Pages is configured to use "GitHub Actions" as the deployment source in the repository settings.

Fixes #2

---

Generated with [Claude Code](https://claude.ai/code)