### PR TITLE
ci: add keepalive job to scheduled workflow

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -49,3 +49,11 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
## Summary
- Add `keepalive` job to `.github/workflows/gh-pages.yaml` that runs only on `schedule` events
- Uses `liskin/gh-workflow-keepalive@v1` with `actions: write` permission
- Prevents GitHub from auto-disabling the 12h cron after 60 days of repository inactivity

## Context
PR #7 (middleware bumps to v5) was merged first; this builds on that.

## Test plan
- [ ] Merge and wait for the next scheduled run (every 12h) to confirm the keepalive job executes
- [ ] Verify the workflow remains enabled after 60 days of no commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)