### PR TITLE
chore(deps): bump requests to >=2.33.0 (security)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = ""
 version = "0.0.1"
 requires-python = ">=3.13.0, <3.14"
 dependencies = [
-    "requests",
+    "requests>=2.33.0",
     "feedgenerator",
     "jinja2>=3.1.6",
     "beautifulsoup4>=4.13.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 2
-requires-python = ">=3.13.0, <3.14"
+revision = 3
+requires-python = "==3.13.*"
 
 [[package]]
 name = ""
@@ -18,7 +18,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
     { name = "feedgenerator" },
     { name = "jinja2", specifier = ">=3.1.6" },
-    { name = "requests" },
+    { name = "requests", specifier = ">=2.33.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -136,7 +136,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -144,9 +144,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin `requests>=2.33.0` in `pyproject.toml`
- Regenerate `uv.lock` (2.32.5 → 2.33.1)

## Context
Addresses Dependabot alert #1 (GHSA, moderate severity): `requests` prior to 2.33.0 had an Insecure Temp File Reuse issue in `extract_zipped_paths()`. We don't call that helper directly, but the pinned floor blocks downgrade regressions and clears the alert on the default branch.

Dependabot didn't auto-open this one because the repo's `dependabot.yml` configures `package-ecosystem: "uv"` — support for the `uv` ecosystem lands separately from classic `pip`, and the grouped update just hasn't surfaced yet. Manual bump in the meantime.

## Test plan
- [x] `uv run main.py` scrapes all 6 feeds successfully with the new version
- [ ] CI `github pages publish` workflow passes
- [ ] Dependabot alert #1 auto-closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)