### PR TITLE
refactor(main): robust parsing + function decomposition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,11 @@ uv run main.py
 5. Renders `templates/index.html` with Jinja2 to create `feeds/index.html`
 
 **Key Files:**
-- `main.py` - Single-file scraper and feed generator
-- `feed.csv` - Comic IDs to track
-- `templates/index.html` - Jinja2 template for feed listing page
+- `main.py` — Scraper + feed generator. Entry point `main()`; helpers
+  `fetch_page`, `parse_comic`, `extract_free_episodes`, `build_atom_feed`,
+  `render_index`.
+- `feed.csv` — Comic IDs to track
+- `templates/index.html` — Jinja2 template for feed listing page
 
 **Deployment:**
 - GitHub Actions workflow runs every 12 hours (`.github/workflows/gh-pages.yaml`)
@@ -38,4 +40,20 @@ uv run main.py
 ## Environment
 
 - Python 3.13 (managed via `uv`)
-- Set `SSL_VERIFY=False` to disable SSL verification if needed
+
+## Adding a Comic
+
+Append the comic's numeric ID (from `alphapolis.co.jp/manga/official/{id}`) as a
+new line in `feed.csv`. Non-digit IDs are skipped with a log line.
+
+## Gotchas
+
+- HTML parsing depends on specific Alphapolis selectors (`h1`, `div.outline`,
+  `div.manga-bigbanner`, `div.episode-unit`, `div.free`, `div.title`,
+  `div.up-time`). If required elements are missing, the affected comic/episode
+  is skipped with a log line — scrapes fail silently per-entry rather than
+  aborting the whole run.
+- `fetch_page` retries once on 5xx / connection errors; 4xx short-circuits
+  (no retry). No exponential backoff.
+- Episode timestamps are interpreted as JST (`Asia/Tokyo`, UTC+9).
+- Output URLs: `https://hanwarai.github.io/alphapolis-rss/{id}.xml`

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import csv
 import re
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import feedgenerator
 import requests
@@ -10,81 +11,146 @@ from jinja2 import Environment, FileSystemLoader
 HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
 }
+FEED_BASE_URL = "https://www.alphapolis.co.jp/manga/official"
+FEED_ID_RE = re.compile(r'\d+')
+UPTIME_DATE_RE = re.compile(r'(\d{4})\.(\d{1,2})\.(\d{1,2})')
+FEEDS_DIR = Path('feeds')
+TEMPLATES_DIR = Path('templates')
+JST = timezone(timedelta(hours=9))
 
-rendered_feeds = []
-with open('feed.csv') as feed_file:
-    for feed in csv.reader(feed_file):
-        feed_id = feed[0]
 
-        if not re.fullmatch(r'\d+', feed_id):
-            print(f"Invalid feed ID: {feed_id!r}, skipping")
+def fetch_page(url):
+    """GET url with one retry on 5xx / connection errors. Returns Response or None."""
+    for attempt in (1, 2):
+        try:
+            resp = requests.get(url, headers=HEADERS, timeout=10)
+        except requests.RequestException as exc:
+            print(f"request error on {url} (attempt {attempt}): {exc}")
+            continue
+        if resp.ok:
+            return resp
+        print(f"{resp.status_code} for {url} (attempt {attempt})")
+        if resp.status_code < 500:
+            return None
+    return None
+
+
+def parse_comic(feed_id, html):
+    """Return comic dict or None if required page elements are missing."""
+    soup = BeautifulSoup(html, 'html.parser')
+    h1 = soup.find('h1')
+    outline = soup.find('div', class_='outline')
+    if h1 is None or outline is None:
+        print(f"Failed to parse page for {feed_id} "
+              f"(h1={h1 is not None}, outline={outline is not None})")
+        return None
+
+    bigbanner = soup.find('div', class_='manga-bigbanner')
+    image_url = bigbanner.img.get('src') if bigbanner and bigbanner.img else None
+
+    return {
+        'title': h1.text.strip(),
+        'description': outline.text.strip(),
+        'image_url': image_url,
+        'episodes': list(extract_free_episodes(soup)),
+    }
+
+
+def extract_free_episodes(soup):
+    """Yield episode dicts for units marked free. Skip entries missing required fields."""
+    for episode in soup.find_all('div', class_='episode-unit'):
+        if episode.find('div', class_='free') is None:
             continue
 
-        comics_url = "https://www.alphapolis.co.jp/manga/official/" + feed_id
-        print(comics_url)
-
-        comics = requests.get(comics_url, headers=HEADERS, verify=True, timeout=10)
-        if not comics.ok:
-            print(f"{comics.status_code} for {feed_id}")
-            comics = requests.get(comics_url, headers=HEADERS, verify=True, timeout=10)
-
-        if not comics.ok:
-            print(f"Failed to retrieve comics for {feed_id}")
+        unique_id = episode.get('data-order')
+        title_el = episode.find('div', class_='title')
+        uptime_el = episode.find('div', class_='up-time')
+        if not unique_id or title_el is None or uptime_el is None:
             continue
 
-        soup = BeautifulSoup(comics.text, 'html.parser')
-
-        h1 = soup.find('h1')
-        if h1 is None:
-            print(f"Failed to parse page for {feed_id} (h1 not found, status={comics.status_code})")
-            print(f"Response body (first 500 chars): {comics.text[:500]}")
+        date_match = UPTIME_DATE_RE.search(uptime_el.text)
+        if date_match is None:
             continue
-        comic_title = h1.text.strip()
-
-        outline = soup.find('div', class_='outline')
-        if outline is None:
-            print(f"Failed to parse page for {feed_id} (outline not found)")
+        try:
+            pubdate = datetime(
+                int(date_match.group(1)),
+                int(date_match.group(2)),
+                int(date_match.group(3)),
+                tzinfo=JST,
+            )
+        except ValueError:
             continue
 
-        bigbanner = soup.find('div', class_='manga-bigbanner')
-        image_url = bigbanner.img.get('src') if bigbanner and bigbanner.img else None
+        yield {
+            'unique_id': unique_id,
+            'title': title_el.text.strip(),
+            'pubdate': pubdate,
+        }
 
-        print(feed_id, comic_title)
-        rendered_feeds.append({'id': feed_id, 'title': comic_title})
 
-        rss = feedgenerator.Atom1Feed(
-            title=comic_title,
-            link=comics_url,
-            description=outline.text.strip(),
-            language="ja",
-            image=image_url
+def build_atom_feed(comic, comics_url):
+    feed = feedgenerator.Atom1Feed(
+        title=comic['title'],
+        link=comics_url,
+        description=comic['description'],
+        language='ja',
+        image=comic['image_url'],
+    )
+    for ep in comic['episodes']:
+        feed.add_item(
+            unique_id=ep['unique_id'],
+            title=ep['title'],
+            link=f"{comics_url}/{ep['unique_id']}",
+            description="",
+            pubdate=ep['pubdate'],
+            content="",
         )
+    return feed
 
-        for episode in soup.find_all('div', class_="episode-unit"):
-            if episode.find('div', class_="free") is None:
+
+def render_index(rendered_feeds):
+    env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)), autoescape=True)
+    template = env.get_template('index.html')
+    (FEEDS_DIR / 'index.html').write_text(
+        template.render(feeds=rendered_feeds),
+        encoding='utf-8',
+    )
+
+
+def main():
+    FEEDS_DIR.mkdir(exist_ok=True)
+    rendered_feeds = []
+
+    with open('feed.csv', encoding='utf-8') as feed_file:
+        for row in csv.reader(feed_file):
+            if not row:
+                continue
+            feed_id = row[0]
+            if not FEED_ID_RE.fullmatch(feed_id):
+                print(f"Invalid feed ID: {feed_id!r}, skipping")
                 continue
 
-            unique_id = episode.get('data-order')
-            uptime = episode.find('div', class_="up-time").text.strip()
-            pubdate = datetime.strptime(uptime.replace('更新', ''), '%Y.%m.%d')
+            comics_url = f"{FEED_BASE_URL}/{feed_id}"
+            print(comics_url)
 
-            rss.add_item(
-                unique_id=unique_id,
-                title=episode.find('div', class_="title").text.strip(),
-                link=comics_url + "/" + unique_id,
-                description="",
-                pubdate=pubdate,
-                content=""
-            )
+            resp = fetch_page(comics_url)
+            if resp is None:
+                print(f"Failed to retrieve comics for {feed_id}")
+                continue
 
-        with open('feeds/' + feed_id + '.xml', 'w') as fp:
-            rss.write(fp, 'utf-8')
+            comic = parse_comic(feed_id, resp.text)
+            if comic is None:
+                continue
 
-# Generate index.html
-jinja_env = Environment(
-    loader=FileSystemLoader('templates'),
-    autoescape=True
-)
-jinja_template = jinja_env.get_template('index.html')
-with open('feeds/index.html', 'w') as index:
-    index.write(jinja_template.render(feeds=rendered_feeds))
+            print(feed_id, comic['title'])
+            rendered_feeds.append({'id': feed_id, 'title': comic['title']})
+
+            feed = build_atom_feed(comic, comics_url)
+            with open(FEEDS_DIR / f"{feed_id}.xml", 'w', encoding='utf-8') as fp:
+                feed.write(fp, 'utf-8')
+
+    render_index(rendered_feeds)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Addresses latent crashes and structural issues surfaced by a code review of `main.py`.

### Critical bug fixes

1. **Unguarded `.text` access (main.py:68,73 on main)** — when an `episode-unit` has a `free` div but is missing `up-time` or `title`, the original code raises `AttributeError` and aborts the entire run (no XML written for that or any subsequent comic). Now guarded per-field with a skip.
2. **`unique_id = None` → TypeError** — `episode.get('data-order')` was concatenated into the URL without None check. Now guarded.

### Additional correctness fixes

- **Date parsing**: `uptime.strip().replace('更新', '')` left a trailing space and failed `strptime`. Now uses `re.search(r'(\d{4})\.(\d{1,2})\.(\d{1,2})')` and constructs `datetime(...)` directly.
- **Timezone**: episode `pubdate`s are now tz-aware JST (UTC+9); feedgenerator/Atom requires tz-aware datetimes.
- **Retry policy**: `fetch_page` retries on 5xx + `RequestException` only; 4xx (404/429/etc.) short-circuits.
- **Encoding**: explicit `encoding='utf-8'` on all file opens.
- **Directory**: `FEEDS_DIR.mkdir(exist_ok=True)` before writing (defensive; the CI env already has it).

### Structural refactor

Extracted helpers — `fetch_page`, `parse_comic`, `extract_free_episodes`, `build_atom_feed`, `render_index` — and wrapped the top-level flow in `main()` with `if __name__ == '__main__'`. Makes each step testable and keeps module import side-effect free.

### Docs

`CLAUDE.md` refreshed to reflect the new structure and fixes. **This PR supersedes #9** (the same doc update, plus required edits for the new code).

## Known separate issue

Running `uv run main.py` against live Alphapolis pages currently yields **0 `<entry>` per comic** for all 6 feeds — both on this branch and on `main`. This is a pre-existing scraping bug (Alphapolis HTML structure appears to have changed; `div.episode-unit`/`div.free` selectors may no longer match free chapters). Not in scope for this PR; will open a separate issue once the selectors are re-identified.

## Test plan

- [x] Unit-style regression test covering: missing `title` / `up-time` / `data-order`, malformed date strings, trailing-space dates, and absent `h1`/`outline`
- [x] End-to-end `uv run main.py` completes without exceptions against live pages (parity with pre-refactor behavior)
- [ ] Merge and verify the scheduled CI `github pages publish` workflow still completes
- [ ] Close PR #9 as superseded after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)