### PR TITLE
fix(scraper): parse episode list from embedded JSON

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,16 @@ new line in `feed.csv`. Non-digit IDs are skipped with a log line.
 
 ## Gotchas
 
-- HTML parsing depends on specific Alphapolis selectors (`h1`, `div.outline`,
-  `div.manga-bigbanner`, `div.episode-unit`, `div.free`, `div.title`,
-  `div.up-time`). If required elements are missing, the affected comic/episode
-  is skipped with a log line — scrapes fail silently per-entry rather than
+- Comic metadata (`h1`, `div.outline`, `div.manga-bigbanner`) is scraped from
+  server-rendered HTML.
+- The **episode list is not in the HTML** — Alphapolis ships it as JSON
+  inside `<div id="app-official-manga-toc"><script type="application/json">`.
+  `extract_free_episodes` parses that payload and filters on
+  `rental.isFree == true`. If Alphapolis changes the container id or the
+  JSON schema (`episodes[].episodeNo / mainTitle / upTime / url / rental.isFree`),
+  all feeds silently emit zero entries.
+- If required HTML or JSON elements are missing, the affected comic/episode is
+  skipped with a log line — scrapes fail silently per-entry rather than
   aborting the whole run.
 - `fetch_page` retries once on 5xx / connection errors; 4xx short-circuits
   (no retry). No exponential backoff.

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -11,7 +12,8 @@ from jinja2 import Environment, FileSystemLoader
 HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
 }
-FEED_BASE_URL = "https://www.alphapolis.co.jp/manga/official"
+ALPHAPOLIS_BASE = "https://www.alphapolis.co.jp"
+FEED_BASE_URL = f"{ALPHAPOLIS_BASE}/manga/official"
 FEED_ID_RE = re.compile(r'\d+')
 UPTIME_DATE_RE = re.compile(r'(\d{4})\.(\d{1,2})\.(\d{1,2})')
 FEEDS_DIR = Path('feeds')
@@ -57,18 +59,36 @@ def parse_comic(feed_id, html):
 
 
 def extract_free_episodes(soup):
-    """Yield episode dicts for units marked free. Skip entries missing required fields."""
-    for episode in soup.find_all('div', class_='episode-unit'):
-        if episode.find('div', class_='free') is None:
+    """Yield episode dicts from the embedded JSON payload.
+
+    Alphapolis renders the episode list client-side; the full list is shipped
+    as JSON inside `<div id="app-official-manga-toc"><script type="application/json">`.
+    """
+    container = soup.find('div', id='app-official-manga-toc')
+    if container is None:
+        return
+    script = container.find('script', type='application/json')
+    if script is None or not script.string:
+        return
+    try:
+        data = json.loads(script.string)
+    except json.JSONDecodeError as exc:
+        print(f"episode JSON decode failed: {exc}")
+        return
+
+    for ep in data.get('episodes', []):
+        rental = ep.get('rental') or {}
+        if not rental.get('isFree'):
             continue
 
-        unique_id = episode.get('data-order')
-        title_el = episode.find('div', class_='title')
-        uptime_el = episode.find('div', class_='up-time')
-        if not unique_id or title_el is None or uptime_el is None:
+        episode_no = ep.get('episodeNo')
+        title = ep.get('mainTitle') or ep.get('shortTitle')
+        up_time = ep.get('upTime', '') or ''
+        url_path = ep.get('url')
+        if episode_no is None or not title or not url_path:
             continue
 
-        date_match = UPTIME_DATE_RE.search(uptime_el.text)
+        date_match = UPTIME_DATE_RE.search(up_time)
         if date_match is None:
             continue
         try:
@@ -82,9 +102,10 @@ def extract_free_episodes(soup):
             continue
 
         yield {
-            'unique_id': unique_id,
-            'title': title_el.text.strip(),
+            'unique_id': str(episode_no),
+            'title': title,
             'pubdate': pubdate,
+            'link': f"{ALPHAPOLIS_BASE}{url_path}",
         }
 
 
@@ -100,7 +121,7 @@ def build_atom_feed(comic, comics_url):
         feed.add_item(
             unique_id=ep['unique_id'],
             title=ep['title'],
-            link=f"{comics_url}/{ep['unique_id']}",
+            link=ep['link'],
             description="",
             pubdate=ep['pubdate'],
             content="",


### PR DESCRIPTION
## Summary

Restores `<entry>` population for all feeds. Alphapolis migrated the episode list to a client-side render: the HTML no longer contains `<div class="episode-unit">` elements, and every generated Atom feed was silently emitting zero entries (just the feed metadata).

## What changed

The full episode list is now shipped as JSON embedded in:

```html
<div id="app-official-manga-toc">
  <script type="application/json">{
    "mangaId": 895000315,
    "mangaTitle": "...",
    "episodes": [
      { "episodeNo": 3502, "url": "/manga/official/895000315/3502",
        "mainTitle": "第1回『そんなよくある物語』",
        "upTime": "2019.12.17更新",
        "rental": {"isFree": true, ...} },
      ...
    ]
  }</script>
</div>
```

`extract_free_episodes` now parses that JSON and filters on `rental.isFree == true`, using `episodeNo` / `mainTitle` / `upTime` / `url` directly from the payload. The HTML scrape for comic-level metadata (`h1`, `div.outline`, `div.manga-bigbanner`) is unchanged.

Episode link URLs come from the JSON's relative `url` field (prepended with `https://www.alphapolis.co.jp`) rather than being constructed as `{comics_url}/{unique_id}` — the two forms agree today, but this decouples us from Alphapolis's URL shape.

## Base

This PR is stacked on **#11** (`refactor/main-py-robustness`) — the JSON extraction builds on the `extract_free_episodes` function decomposition introduced there. Will rebase onto `main` after #11 merges.

## Verification

Live run after the change (all 6 feeds now populated):

```
feeds/48000051.xml: 13 entries
feeds/220000195.xml: 3 entries
feeds/443000228.xml: 8 entries
feeds/552000104.xml: 5 entries
feeds/830000061.xml: 6 entries
feeds/895000315.xml: 11 entries
```

Latest visible entry: `第65回『対決オークロード』` dated 2026-04-21 (today) — confirming we're reading live data.

## Test plan

- [x] Regression tests: missing container, missing script tag, malformed JSON, empty JSON, mixed free/non-free/missing-field entries — all handled with per-entry skips
- [x] Live end-to-end run produces non-empty feeds across all 6 comics
- [ ] Merge #11 → this PR → verify the scheduled `github pages publish` run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)