### PR TITLE
fix(scraper): browser-like headers + diagnostic body dump

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,17 @@ from bs4 import BeautifulSoup
 from jinja2 import Environment, FileSystemLoader
 
 HEADERS = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+    'Accept-Language': 'ja,en-US;q=0.7,en;q=0.3',
+    'Accept-Encoding': 'gzip, deflate, br',
+    'DNT': '1',
+    'Connection': 'keep-alive',
+    'Upgrade-Insecure-Requests': '1',
+    'Sec-Fetch-Dest': 'document',
+    'Sec-Fetch-Mode': 'navigate',
+    'Sec-Fetch-Site': 'none',
+    'Sec-Fetch-User': '?1',
 }
 ALPHAPOLIS_BASE = "https://www.alphapolis.co.jp"
 FEED_BASE_URL = f"{ALPHAPOLIS_BASE}/manga/official"
@@ -44,7 +54,9 @@ def parse_comic(feed_id, html):
     outline = soup.find('div', class_='outline')
     if h1 is None or outline is None:
         print(f"Failed to parse page for {feed_id} "
-              f"(h1={h1 is not None}, outline={outline is not None})")
+              f"(h1={h1 is not None}, outline={outline is not None}, "
+              f"html_len={len(html)})")
+        print(f"  body[:400]: {html[:400]!r}")
         return None
 
     bigbanner = soup.find('div', class_='manga-bigbanner')


### PR DESCRIPTION
## Summary

After #13 deployed, the CI run produced 0-entry feeds with the log:

```
https://www.alphapolis.co.jp/manga/official/895000315
Failed to parse page for 895000315 (h1=False, outline=False)
```

Locally the same URL returns a 188 KB page with `h1=True, outline=True`. The difference is the request's network fingerprint: GH Actions runners sit on Azure datacenter IPs, and Alphapolis appears to serve a stripped response to requests that look like bare `requests` calls (UA only, no Accept-Language, etc.).

## Fix

Add the standard browser-navigation header set:
- `Accept`, `Accept-Language: ja,...`, `Accept-Encoding`
- `DNT`, `Upgrade-Insecure-Requests`, `Connection`
- `Sec-Fetch-Dest/Mode/Site/User` (modern fetch metadata)

Also restore the response-body dump when `h1`/`outline` are missing, so future failures show in CI logs what we actually received.

## Test plan

- [x] Local `uv run main.py` still produces non-empty feeds for all 6 comics
- [ ] Merge and check the next CI run populates `hanwarai.github.io/alphapolis-rss/*.xml`
- [ ] If still blocked, the diagnostic dump shows whether the response is an interstitial, cloudflare, empty shell, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)